### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,4 +1,6 @@
 name: pre-commit
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Frodothedwarf/dynamic-readme-meme/security/code-scanning/1](https://github.com/Frodothedwarf/dynamic-readme-meme/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The minimal starting point is to set `contents: read`, which allows the workflow to read repository contents but not write to them. This should be added at the workflow level (top-level, after the `name` and before `on:`) to apply to all jobs, unless a job requires additional permissions. No changes to the steps or other workflow logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
